### PR TITLE
Port Omniscience to Minecraft 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'fabric-loom' version '1.9.2'
 	id 'maven-publish'
 }
 
@@ -35,12 +35,11 @@ loom {
 	splitEnvironmentSourceSets()
 
 	mods {
-		"modid" {
+		"omniscience" {
 			sourceSet sourceSets.main
 			sourceSet sourceSets.client
 		}
 	}
-
 }
 
 
@@ -65,7 +64,7 @@ dependencies {
 	}
 }
 
-processResources {
+tasks.withType(ProcessResources).configureEach {
 	inputs.property "version", project.version
 
 	filesMatching("fabric.mod.json") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,21 +3,21 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.3
-loader_version=0.16.9
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
+loader_version=0.16.13
 
 # Mod Properties
 mod_version = 1.0.6
 maven_group = com.mrqueequeg
-archives_base_name = omniscience-fabric-mc1.20.6
+archives_base_name = omniscience-fabric-mc1.21.1
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.100.8+1.20.6
+fabric_version=0.115.4+1.21.1
 
 # Cloth Config
-cloth_config_version=14.0.139
+cloth_config_version=15.0.140
 
 # Mod Menu
-mod_menu_version=10.0.0
+mod_menu_version=11.0.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/com/thatdudo/omniscience/mixin/FeatureRendererMixin.java
+++ b/src/client/java/com/thatdudo/omniscience/mixin/FeatureRendererMixin.java
@@ -1,0 +1,30 @@
+package com.thatdudo.omniscience.mixin;
+
+import com.thatdudo.omniscience.config.ConfigManager;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.util.Identifier;
+import net.minecraft.client.render.entity.feature.FeatureRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(FeatureRenderer.class)
+public class FeatureRendererMixin {
+
+    @Redirect(
+            method = "renderModel",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/render/RenderLayer;getEntityCutoutNoCull(Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/RenderLayer;"
+            )
+    )
+    private static RenderLayer omniscience$useTranslucent(Identifier texture) {
+
+        if (ConfigManager.getConfig().isEnabled()
+                && texture.getPath().startsWith("textures/entity/villager/")) {
+            return RenderLayer.getEntityTranslucent(texture);
+        }
+
+        return RenderLayer.getEntityCutoutNoCull(texture);
+    }
+}

--- a/src/client/java/com/thatdudo/omniscience/mixin/ModelPartMixin.java
+++ b/src/client/java/com/thatdudo/omniscience/mixin/ModelPartMixin.java
@@ -4,18 +4,32 @@ import com.thatdudo.omniscience.config.ConfigManager;
 import net.minecraft.client.model.ModelPart;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(ModelPart.class)
 public class ModelPartMixin {
 
-    @ModifyVariable(at = @At("HEAD"), method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;IIFFFF)V", ordinal = 3, argsOnly=true)
-    private float onRender(float alpha) {
-        if (ConfigManager.getConfig().isEnabled()) {
-            if (alpha != 1.0f) {
-                return ConfigManager.getConfig().alpha;
-            }
+    @ModifyArg(
+            method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;III)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/model/ModelPart;renderCuboids(Lnet/minecraft/client/util/math/MatrixStack$Entry;Lnet/minecraft/client/render/VertexConsumer;III)V"
+            ),
+            index = 4
+    )
+    private int modifyColor(int color) {
+        if (!ConfigManager.getConfig().isEnabled()) {
+            return color;
         }
-        return alpha;
+
+        int alpha = (color >>> 24) & 0xFF;
+
+        if (alpha == 255) {
+            return color;
+        }
+
+        int configuredAlpha = Math.round(ConfigManager.getConfig().alpha * 255.0f);
+
+        return (configuredAlpha << 24) | (color & 0x00FFFFFF);
     }
 }

--- a/src/client/java/com/thatdudo/omniscience/mixin/SheepWoolFeatureRendererMixin.java
+++ b/src/client/java/com/thatdudo/omniscience/mixin/SheepWoolFeatureRendererMixin.java
@@ -13,7 +13,9 @@ import net.minecraft.client.render.entity.model.SheepEntityModel;
 import net.minecraft.client.render.entity.model.SheepWoolEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.passive.SheepEntity;
+import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.ColorHelper.Argb;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -24,38 +26,114 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(SheepWoolFeatureRenderer.class)
 public class SheepWoolFeatureRendererMixin {
 
-    @Shadow @Final private static Identifier SKIN;
-    @Shadow @Final private SheepWoolEntityModel<SheepEntity> model;
+    @Shadow @Final
+    private static Identifier SKIN;
+
+    @Shadow @Final
+    private SheepWoolEntityModel<SheepEntity> model;
 
     private FeatureRendererContext<SheepEntity, SheepEntityModel<SheepEntity>> _context;
 
-
     @Inject(at = @At("RETURN"), method = "<init>")
-    private void onInit(FeatureRendererContext<SheepEntity, SheepEntityModel<SheepEntity>> context, EntityModelLoader loader, CallbackInfo ci) {
+    private void onInit(
+            FeatureRendererContext<SheepEntity, SheepEntityModel<SheepEntity>> context,
+            EntityModelLoader loader,
+            CallbackInfo ci
+    ) {
         this._context = context;
     }
 
-    @Inject(at = @At("HEAD"), method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/entity/passive/SheepEntity;FFFFFF)V")
-    private void onRender(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, SheepEntity sheepEntity, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
+    @Inject(
+            at = @At("HEAD"),
+            method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/entity/passive/SheepEntity;FFFFFF)V"
+    )
+    private void onRender(
+            MatrixStack matrixStack,
+            VertexConsumerProvider vertexConsumerProvider,
+            int light,
+            SheepEntity sheepEntity,
+            float limbAngle,
+            float limbDistance,
+            float tickDelta,
+            float customAngle,
+            float headYaw,
+            float headPitch,
+            CallbackInfo ci
+    ) {
         Config config = ConfigManager.getConfig();
 
-        if (config.isEnabled() && sheepEntity.isInvisible() && !sheepEntity.isSheared() && config.isEntityTargeted(sheepEntity)) {
-            // Sheep wool needs to be rendered manually since its not rendered if the sheep is invisible
-            int woolColor = SheepEntity.getRgbColor(sheepEntity.getColor());
-
-            _context.getModel().copyStateTo(this.model);
-            this.model.animateModel(sheepEntity, f, g, h);
-            this.model.setAngles(sheepEntity, f, g, j, k, l);
-
-            VertexConsumer vertexConsumer2 =
-                    vertexConsumerProvider.getBuffer(RenderLayer.getItemEntityTranslucentCull(SKIN));
-
-            this.model.render(
-                    matrixStack,
-                    vertexConsumer2,
-                    i,
-                    LivingEntityRenderer.getOverlay(sheepEntity, 0.0f)
-            );
+        if (!config.isEnabled()
+                || !sheepEntity.isInvisible()
+                || sheepEntity.isSheared()
+                || !config.isEntityTargeted(sheepEntity)) {
+            return;
         }
+
+        /*
+         * Calculate the wool color exactly like vanilla.
+         */
+        int woolColor;
+
+        if (sheepEntity.hasCustomName()
+                && "jeb_".equals(sheepEntity.getName().getString())) {
+
+            int n = sheepEntity.age / 25 + sheepEntity.getId();
+            int o = DyeColor.values().length;
+
+            int p = n % o;
+            int q = (n + 1) % o;
+
+            float r = ((float) (sheepEntity.age % 25) + tickDelta) / 25.0F;
+
+            int s = SheepEntity.getRgbColor(DyeColor.byId(p));
+            int t = SheepEntity.getRgbColor(DyeColor.byId(q));
+
+            woolColor = Argb.lerp(r, s, t);
+
+        } else {
+            woolColor = SheepEntity.getRgbColor(sheepEntity.getColor());
+        }
+
+        /*
+         * Apply Omniscience transparency.
+         */
+        int alpha = (int) (config.alpha * 255.0F);
+        alpha = Math.max(0, Math.min(255, alpha));
+
+        int color = (alpha << 24) | (woolColor & 0x00FFFFFF);
+
+        /*
+         * Copy the normal sheep model state to the wool model.
+         */
+        _context.getModel().copyStateTo(this.model);
+
+        this.model.animateModel(
+                sheepEntity,
+                limbAngle,
+                limbDistance,
+                tickDelta
+        );
+
+        this.model.setAngles(
+                sheepEntity,
+                limbAngle,
+                limbDistance,
+                customAngle,
+                headYaw,
+                headPitch
+        );
+
+        VertexConsumer vertexConsumer =
+                vertexConsumerProvider.getBuffer(
+                        RenderLayer.getItemEntityTranslucentCull(SKIN)
+                );
+
+        this.model.render(
+                matrixStack,
+                vertexConsumer,
+                light,
+                LivingEntityRenderer.getOverlay(sheepEntity, 0.0F),
+                color
+        );
     }
 }

--- a/src/client/java/com/thatdudo/omniscience/mixin/SheepWoolFeatureRendererMixin.java
+++ b/src/client/java/com/thatdudo/omniscience/mixin/SheepWoolFeatureRendererMixin.java
@@ -41,12 +41,21 @@ public class SheepWoolFeatureRendererMixin {
 
         if (config.isEnabled() && sheepEntity.isInvisible() && !sheepEntity.isSheared() && config.isEntityTargeted(sheepEntity)) {
             // Sheep wool needs to be rendered manually since its not rendered if the sheep is invisible
-            float[] woolColors = SheepEntity.getRgbColor(sheepEntity.getColor());
+            int woolColor = SheepEntity.getRgbColor(sheepEntity.getColor());
+
             _context.getModel().copyStateTo(this.model);
             this.model.animateModel(sheepEntity, f, g, h);
             this.model.setAngles(sheepEntity, f, g, j, k, l);
-            VertexConsumer vertexConsumer2 = vertexConsumerProvider.getBuffer(RenderLayer.getItemEntityTranslucentCull(SKIN));
-            this.model.render(matrixStack, vertexConsumer2, i, LivingEntityRenderer.getOverlay(sheepEntity, 0.0f), woolColors[0], woolColors[1], woolColors[2], 0.15f);
+
+            VertexConsumer vertexConsumer2 =
+                    vertexConsumerProvider.getBuffer(RenderLayer.getItemEntityTranslucentCull(SKIN));
+
+            this.model.render(
+                    matrixStack,
+                    vertexConsumer2,
+                    i,
+                    LivingEntityRenderer.getOverlay(sheepEntity, 0.0f)
+            );
         }
     }
 }

--- a/src/client/java/com/thatdudo/omniscience/mixin/VillagerClothingFeatureRendererMixin.java
+++ b/src/client/java/com/thatdudo/omniscience/mixin/VillagerClothingFeatureRendererMixin.java
@@ -1,0 +1,51 @@
+package com.thatdudo.omniscience.mixin;
+
+import com.thatdudo.omniscience.config.Config;
+import com.thatdudo.omniscience.config.ConfigManager;
+import net.minecraft.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(net.minecraft.client.render.entity.feature.VillagerClothingFeatureRenderer.class)
+public class VillagerClothingFeatureRendererMixin {
+
+    @Redirect(
+            method = "render",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/LivingEntity;isInvisible()Z"
+            )
+    )
+    private boolean omniscience$shouldRenderClothing(LivingEntity entity) {
+        Config config = ConfigManager.getConfig();
+
+        if (config.isEnabled()
+                && entity.isInvisible()
+                && config.isEntityTargeted(entity)) {
+            return false;
+        }
+
+        return entity.isInvisible();
+    }
+
+    @ModifyConstant(
+            method = "render",
+            constant = @Constant(intValue = -1)
+    )
+    private int omniscience$modifyClothingColor(int color) {
+        Config config = ConfigManager.getConfig();
+
+        if (!config.isEnabled()) {
+            return color;
+        }
+
+        int alpha = Math.round(config.alpha * 255.0f);
+        alpha = Math.max(0, Math.min(255, alpha));
+
+        return (alpha << 24) | 0x00FFFFFF;
+    }
+
+}

--- a/src/client/resources/assets/omniscience/lang/zh_tw.json
+++ b/src/client/resources/assets/omniscience/lang/zh_tw.json
@@ -1,0 +1,42 @@
+{
+  "message.enabled": "已啟用 %s",
+  "message.disabled": "已停用 %s",
+
+  "key.category.omniscience": "全知 (Omniscience)",
+  "key.omniscience.settings": "開啟設定",
+  "key.omniscience.enable": "切換啟用狀態",
+
+  "config.generic.title": "一般選項",
+  "config.generic.enabled.title": "啟用模組",
+  "config.generic.enabled.tooltip": "完全啟用或停用此模組",
+
+  "config.generic.alpha.title": "目標透明度",
+  "config.generic.alpha.tooltip": "設定隱形實體的半透明度",
+  "config.generic.glow.title": "發光高亮隱形實體",
+  "config.generic.glow.tooltip": "選定的目標在隱形時獲得發光效果",
+  "config.generic.glow.option.none": "無",
+  "config.generic.glow.option.player": "玩家",
+  "config.generic.glow.option.match_targets": "指定目標",
+
+  "config.generic.targeted.title": "顯示目標",
+  "config.generic.targeted.tooltip": "選擇要揭露顯示的隱形實體類型",
+  "config.generic.targeted.all.title": "全部",
+  "config.generic.targeted.players.title": "玩家",
+  "config.generic.targeted.monster.title": "怪物",
+  "config.generic.targeted.villager.title": "村民/NPC",
+  "config.generic.targeted.animals.title": "動物",
+  "config.generic.targeted.objects.title": "掉落物與物件",
+
+  "config.generic.misc.title": "雜項",
+  "config.generic.misc.remove_blindness.title": "移除失明效果",
+  "config.generic.misc.remove_blindness.tooltip": "移除失明效果所產生的迷霧遮罩",
+  "config.generic.misc.expose_barriers.title": "顯現屏障方塊",
+  "config.generic.misc.expose_barriers.tooltip": "不需要手持屏障方塊或切換至創造模式\n即可直接高亮顯示屏障方塊",
+  "config.generic.misc.name_tags.title": "強制顯示名牌",
+  "config.generic.misc.name_tags.tooltip": "強制渲染實體與玩家的名牌\n選擇「總是」可繞過伺服器插件限制",
+  "config.generic.misc.name_tags.option.never": "無",
+  "config.generic.misc.name_tags.option.when_sneaking": "蹲下時",
+  "config.generic.misc.name_tags.option.always": "總是",
+  "config.generic.misc.only_creative.title": "僅限創造模式",
+  "config.generic.misc.only_creative.tooltip": "僅在遊戲模式設為創造模式時才啟用此模組"
+}

--- a/src/client/resources/fabric.mod.json
+++ b/src/client/resources/fabric.mod.json
@@ -30,9 +30,9 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
+    "fabricloader": ">=0.16.13",
     "fabric": "*",
-    "minecraft": "1.20.x"
+    "minecraft": "1.21.1"
   },
   "suggests": {
     "another-mod": "*"

--- a/src/client/resources/omniscience.mixins.json
+++ b/src/client/resources/omniscience.mixins.json
@@ -12,7 +12,9 @@
     "ClientPlayerInteractionManagerMixin",
     "BackgroundRendererMixin",
     "ClientWorldMixin",
-    "SheepWoolFeatureRendererMixin"
+    "SheepWoolFeatureRendererMixin",
+    "VillagerClothingFeatureRendererMixin",
+    "FeatureRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/client/resources/omniscience.mixins.json
+++ b/src/client/resources/omniscience.mixins.json
@@ -3,8 +3,7 @@
   "minVersion": "0.8",
   "package": "com.thatdudo.omniscience.mixin",
   "compatibilityLevel": "JAVA_21",
-  "mixins": [
-  ],
+  "mixins": [],
   "client": [
     "EntityMixin",
     "ModelPartMixin",


### PR DESCRIPTION
## Summary

- Port Omniscience from Minecraft 1.20.4 to Minecraft 1.21.1
- Update Minecraft mappings and Fabric dependencies
- Update rendering-related code for the 1.21.1 `ModelPart` API changes
- Update Mod Menu / Cloth Config compatibility
- Add Traditional Chinese (`zh_tw`) localization

## Testing

Tested successfully on Minecraft 1.21.1 with Fabric Loader 0.16.13.

Verified:
- Mod loads successfully
- Invisible entities are rendered correctly
- Configurable transparency works correctly
- Mod Menu configuration screen works
- Existing entity targeting features continue to work

## Notes

The 1.21.1 version has been tested in a development environment and the resulting JAR has been built successfully.